### PR TITLE
feat: save request data

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,3 +5,8 @@ OPTIMISM_RPC_URL=
 ARBITRUM_ONE_RPC_URL=
 POLYGON_RPC_URL=
 GNOSIS_CHAIN_RPC_URL=
+
+# Only needed if you want to save data to airtable, ignored if empty.
+AIRTABLE_BASE_ID=
+AIRTABLE_TABLE_ID=
+AIRTABLE_PAT=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-log",
  "tracing-subscriber",
+ "uuid 1.3.3",
  "walkdir",
 ]
 
@@ -4021,7 +4022,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.3.0",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -4274,11 +4275,12 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,14 @@
     "util",
     "cors",
   ] }
-  tracing = "0.1.37"
+  tracing = { version = "0.1.37", features = ["log"] }
   tracing-bunyan-formatter = "0.3.6"
   tracing-log = "0.1.3"
   tracing-subscriber = { version = "0.3.16", features = [
     "registry",
     "env-filter",
   ] }
+  uuid = { version = "1.3.3", features = ["v4", "serde"] }
   walkdir = "2.3.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@
   headers = "0.3.8"
   heimdall = { git = "https://github.com/Jon-Becker/heimdall-rs.git", version = "0.4.5" }
   hyper = "0.14.25"
+  reqwest = "0.11.14"
   serde = { version = "1.0.155", features = ["derive"] }
   serde_json = "1.0.94"
   tempfile = "3.4.0"
@@ -36,4 +37,3 @@
 
 [dev-dependencies]
   once_cell = "1.17.1"
-  reqwest = "0.11.14"

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -1,5 +1,10 @@
 use axum::http;
+use uuid::Uuid;
 
+#[tracing::instrument(
+    name = "Health check",
+    fields(request_id = %Uuid::new_v4())
+)]
 pub async fn health_check() -> http::StatusCode {
     http::StatusCode::OK
 }

--- a/src/routes/verify.rs
+++ b/src/routes/verify.rs
@@ -26,6 +26,7 @@ use std::{
     result::Result,
 };
 use tempfile::TempDir;
+use uuid::Uuid;
 
 #[derive(Deserialize, Debug)]
 pub enum BuildFramework {
@@ -39,14 +40,14 @@ pub enum BuildFramework {
     Truffle,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct BuildConfig {
     framework: BuildFramework,
     // For forge, this is the profile name.
     build_hint: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct VerifyData {
     repo_url: String,
     repo_commit: String,
@@ -131,9 +132,11 @@ impl_from_for_verify_error!(serde_json::Error);
     name = "Verifying contract",
     skip(json),
     fields(
+        request_id = %Uuid::new_v4(),
         repo_url = %json.repo_url,
         repo_commit = %json.repo_commit,
-        contract_address = %json.contract_address,
+        contract_address = ?json.contract_address,
+        creation_tx_hashes = ?json.creation_tx_hashes,
     )
 )]
 pub async fn verify(Json(json): Json<VerifyData>) -> Result<Response, VerifyError> {


### PR DESCRIPTION
For the alpha release, we'll save off the request data so we can make sure things are working as intended, and for requests that fail, we can re-test and improve the product. Just saving data to airtable for simplicity/convenience for now since our API logging isn't setup yet